### PR TITLE
Update Cisco-IOS-XR-qos-ma-oper.yang

### DIFF
--- a/vendor/cisco/xr/611/Cisco-IOS-XR-qos-ma-oper.yang
+++ b/vendor/cisco/xr/611/Cisco-IOS-XR-qos-ma-oper.yang
@@ -828,7 +828,7 @@ module Cisco-IOS-XR-qos-ma-oper {
       description "to maintain satellite id";
     }
 
-    list class-stat {
+    list class-stats {
       description "array of classes contained in policy";
       uses CLASS-STATS;
     }


### PR DESCRIPTION
Typo in list definition:
- list class-stat {    <- xr platform returns an error
+ list class-stats {